### PR TITLE
Component-ize and clean up Slider table 

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -6,7 +6,7 @@
 
     <!-- use a transition group to animate the table -->
     <thead>
-      <tr>
+      <tr class="tl">
         <th>Oblast</th>
         <th>Harvested Area</th>
         <th>Yield</th>
@@ -18,12 +18,11 @@
         v-for="oblast in sortedDataByGrainType"
         :key="oblast.oblastNameUkrainian"
       >
-        <td>{{ oblast.oblastNameEnglish }}</td>
         <td>{{ oblast.oblastNameUkrainian }}</td>
         <td>{{ oblast.harvestedArea }}</td>
         <td>{{ oblast.grainYield }}</td>
         <td>{{ oblast.volume }}</td>
-        <td class="tr">
+        <td class="tl">
           <div class="slider-cell">
             <input
               type="range"
@@ -36,10 +35,8 @@
               :value="getOblastPercentage(oblast.oblastNameUkrainian)"
               :id="`range-${oblast.oblastNameUkrainian}`"
             />
+            {{ getOblastPercentage(oblast.oblastNameUkrainian) }}%
           </div>
-        </td>
-        <td class="tl">
-          {{ getOblastPercentage(oblast.oblastNameUkrainian) }}%
         </td>
       </tr>
     </TransitionGroup>
@@ -48,9 +45,9 @@
     <tfoot>
       <tr class="bg-gray white">
         <td>Total</td>
-        <td>{{ numberFormat(totalHarvestedArea) }}</td>
-        <td>{{ numberFormat(totalYield) }}</td>
-        <td>{{ numberFormat(totalVolume) }}</td>
+        <td>{{ totalHarvestedArea }}</td>
+        <td>{{ totalYield }}</td>
+        <td>{{ totalVolume }}</td>
       </tr>
     </tfoot>
   </table>
@@ -60,15 +57,24 @@ import * as d3 from "d3";
 const props = defineProps([
   "dataByGrainType",
   "sortedDataByGrainType",
-  "totalHarvestedArea",
-  "totalYield",
-  "totalVolume",
 ]);
 const emit = defineEmits(["sliderChange"]);
 
 const numberFormat = d3.format(",.0f");
 
 const oblastSliderPercentages = ref({});
+
+// sums up the values for a given column
+function computeTotal(columnKey) {
+  if (!props.sortedDataByGrainType) return 0;
+  return props.sortedDataByGrainType.reduce(
+    (acc, { [columnKey]: value }) => acc + (+value), 0
+  ).toFixed(1)
+}
+
+const totalHarvestedArea = computed(() => computeTotal('harvestedArea'));
+const totalYield = computed(() => computeTotal('grainYield'));
+const totalVolume = computed(() => computeTotal('volume'));
 
 function getOblastPercentage(oblastName) {
   const scalar = oblastSliderPercentages.value[oblastName];

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -33,15 +33,13 @@
               @change="
                 setOblastScale($event.target.value, oblast.oblastNameUkrainian)
               "
-              :value="
-                oblastSliderPercentages[oblast.oblastNameUkrainian] || 100
-              "
+              :value="getOblastPercentage(oblast.oblastNameUkrainian)"
               :id="`range-${oblast.oblastNameUkrainian}`"
             />
           </div>
         </td>
         <td class="tl">
-          {{ oblastSliderPercentages[oblast.oblastNameUkrainian] }}%
+          {{ getOblastPercentage(oblast.oblastNameUkrainian) }}%
         </td>
       </tr>
     </TransitionGroup>
@@ -71,32 +69,20 @@ const emit = defineEmits(["sliderChange"]);
 const numberFormat = d3.format(",.0f");
 
 const oblastSliderPercentages = ref({});
-// we only watch the original data so that we don't recompute this on every slider change
-watch(
-  () => props.dataByGrainType,
-  (newVal, oldVal) => {
-    // lets look at the forecasted data and calculate the percent
-    // most likely the forecasted data is available (if not we default to 100%)
-    let forecast = props.sortedDataByGrainType;
-    if (forecast) {
-      let v;
-      for (let oblast of forecast) {
-        // we still may not have an original vs forecasted value so again we default to 100%
-        v = Math.round((+oblast.volume / +oblast.volumeOriginal) * 100);
-        if (isNaN(v)) v = 100;
-        oblastSliderPercentages.value[oblast.oblastNameUkrainian] = v;
-      }
-    } else {
-      for (let oblast of newVal) {
-        // if(!oblastSliderPercentages[oblast.oblastNameUkrainian])
-        oblastSliderPercentages.value[oblast.oblastNameUkrainian] = 100;
-      }
-    }
+
+function getOblastPercentage(oblastName) {
+  const scalar = oblastSliderPercentages.value[oblastName];
+  // since 0 is falsey we can't easily default to 1 :(
+  if (scalar === 0) {
+    return 0;
   }
-);
+  // default scalar is 1
+  return ((scalar || 1) * 100).toFixed();
+}
 
 function setOblastScale(percentage, oblastName) {
-  oblastSliderPercentages.value[oblastName] = +percentage;
+  // convert to a scalar before emit
+  oblastSliderPercentages.value[oblastName] = (+percentage) / 100;
   emit("sliderChange", oblastSliderPercentages.value);
 }
 </script>

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,9 +1,5 @@
 <template>
   <table id="data-table">
-    <!-- <pre v-if="dataByGrainType">
-        {{dataByGrainType.get(activeGrainType)}}
-      </pre> -->
-
     <!-- use a transition group to animate the table -->
     <thead>
       <tr class="tl">
@@ -55,8 +51,8 @@
 <script setup>
 import * as d3 from "d3";
 const props = defineProps([
-  "dataByGrainType",
   "sortedDataByGrainType",
+  "initialScenario"
 ]);
 const emit = defineEmits(["sliderChange"]);
 
@@ -77,13 +73,15 @@ const totalYield = computed(() => computeTotal('grainYield'));
 const totalVolume = computed(() => computeTotal('volume'));
 
 function getOblastPercentage(oblastName) {
-  const scalar = oblastSliderPercentages.value[oblastName];
+  const initScalar = props.initialScenario[oblastName];
+  const userSetScalar = oblastSliderPercentages.value[oblastName];
+  const scalarToPercentage = scalar => (scalar * 100).toFixed();
   // since 0 is falsey we can't easily default to 1 :(
-  if (scalar === 0) {
+  if (initScalar === 0 || userSetScalar === 0) {
     return 0;
   }
-  // default scalar is 1
-  return ((scalar || 1) * 100).toFixed();
+  // if the slider has set a percentage, use that, otherwise fallback on the init, and finally 100%
+  return scalarToPercentage(userSetScalar || initScalar || 1)
 }
 
 function setOblastScale(percentage, oblastName) {

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -18,11 +18,11 @@
         v-for="oblast in sortedDataByGrainType"
         :key="oblast.oblastNameUkrainian"
       >
-        <td>{{ oblast.oblastNameUkrainian }}</td>
-        <td>{{ oblast.harvestedArea }}</td>
-        <td>{{ oblast.grainYield }}</td>
-        <td>{{ oblast.volume }}</td>
-        <td class="tl">
+        <td class="w-20">{{ oblast.oblastNameUkrainian }}</td>
+        <td class="w-20">{{ oblast.harvestedArea }}</td>
+        <td class="w-20">{{ oblast.grainYield }}</td>
+        <td class="w-20">{{ oblast.volume }}</td>
+        <td class="tl w-20">
           <div class="slider-cell">
             <input
               type="range"

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -83,11 +83,13 @@
         <button @click="clearSelectedOblasts">Clear</button>
       </div>
 
+      <!-- sample initial scenario -->
       <DataTable
         :sorted-data-by-grain-type="sortedDataByGrainType"
-        :total-harvested-area="0"
-        :total-yield="0"
-        :total-volume="0"
+        :initial-scenario="{
+          // sample scenario sets the first oblast to 50%
+          '7260': 0.5
+        }"
         class="w-100 bt b--light-gray mt2 fl"
         @sliderChange="updateScaleByOblast"
       />

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -84,7 +84,6 @@
       </div>
 
       <DataTable
-        :data-by-grain-type="originalDataByGrainType"
         :sorted-data-by-grain-type="sortedDataByGrainType"
         :total-harvested-area="0"
         :total-yield="0"

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -86,7 +86,7 @@
       <!-- sample initial scenario -->
       <DataTable
         :sorted-data-by-grain-type="sortedDataByGrainType"
-        :initial-scenario="{
+        :scenario="{
           // sample scenario sets the first oblast to 50%
           '7260': 0.5
         }"
@@ -167,9 +167,10 @@ const forecastSelectOptions = [
 function formatAndScaleValue(value, oblastNameUkrainian) {
   // default to 100% if missing from scaleByOblast map
   const scale = scaleByOblast.value[oblastNameUkrainian];
-  const sliderScale = (scale >= 0 ? scale : 100) / 100;
+  const sliderScale = (scale >= 0 ? scale : 1);
   return formatValue(value * sliderScale);
 }
+
 function formatValue(value) {
   return (+value).toFixed(1);
 }


### PR DESCRIPTION
Closes #36 

Table component now:
- emits an object of scalars that the parent component (map.js) uses to scale the data
- is a more of a 'dumb' table - it doesn't sort or scale, just displays and sums up totals
- sums up numerical table columns (the "total" row is now correct & updates with the sliders)
- accepts a `scenario` prop which allows us to set the sliders to initial scalar values for each oblast
- got a minor facelift, the columns now scale evenly and the headers are lined up
<img width="1346" alt="Screen Shot 2023-02-13 at 9 08 19 PM" src="https://user-images.githubusercontent.com/4695062/218644714-770a6718-e8fa-4ce3-80fd-78ee1b04184c.png">
